### PR TITLE
fix: uppercase client_type, fix log var, add strip param to tool parser

### DIFF
--- a/src/api/quick.py
+++ b/src/api/quick.py
@@ -180,8 +180,8 @@ async def quick_endpoint(
         raise HTTPException(status_code=401, detail="Unauthorized")
     
     # 2. Validar tipo de cliente
-    client_type = client_data.get("client_type", "chat")
-    if client_type != "quick":
+    client_type = client_data.get("client_type", "CHAT")
+    if client_type != "QUICK":
         raise HTTPException(
             status_code=403, 
             detail=f"Client type '{client_type}' not allowed on /quick endpoint. Expected 'quick'."

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -252,7 +252,7 @@ class MemoryManager:
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"Failed to get conversations for user {user_id}: {e}")
+            logger.error(f"Failed to get conversations for client {client_id}: {e}")
             return []
 
     async def save_message(

--- a/src/utils/tool_parser.py
+++ b/src/utils/tool_parser.py
@@ -95,7 +95,7 @@ def validate_tool_call(tool_call: dict, available_tools: list[str]) -> tuple[boo
     return True, ""
 
 
-def remove_tool_calls_from_text(text: str) -> str:
+def remove_tool_calls_from_text(text: str, strip: bool = False) -> str:
     """Remove all <tool_call>...</tool_call> blocks from text.
 
     Also collapses any blank lines left behind when a tool call occupied
@@ -103,12 +103,15 @@ def remove_tool_calls_from_text(text: str) -> str:
 
     Args:
         text: Raw model output that may contain tool_call blocks.
+        strip: If True, strip leading/trailing whitespace from the result.
+               Leave False when processing individual streaming tokens to
+               preserve inter-word spaces.
 
     Returns:
         Cleaned text with all tool_call blocks removed.
     """
     cleaned = TOOL_CALL_PATTERN.sub("", text)
     # Collapse 3+ consecutive newlines (left by a standalone tool_call line)
-    # down to a single blank line, then strip leading/trailing whitespace.
+    # down to a single blank line.
     cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
-    return cleaned.strip()
+    return cleaned.strip() if strip else cleaned


### PR DESCRIPTION
## Summary
- **quick.py**: compara `client_type` contra `QUICK`/`CHAT` en mayúsculas para coincidir con los valores del servicio de auth
- **memory.py**: corrige mensaje de error que usaba `user_id` en lugar de `client_id`
- **tool_parser.py**: añade parámetro `strip` a `remove_tool_calls_from_text` para evitar recortar espacios entre palabras al procesar tokens de streaming

## Test Plan
- [x] 33 tests unitarios e integración pasan (`pytest tests/unit/ tests/integration/`)
- [x] Cambios probados manualmente por el autor

🤖 Generated with [Claude Code](https://claude.com/claude-code)