### PR TITLE
fix(memory): use real client UUID in conversations, extra_data in messages

### DIFF
--- a/src/api/chat/websocket.py
+++ b/src/api/chat/websocket.py
@@ -44,10 +44,10 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
         return
         
     # 2. Validar tipo de cliente
-    client_type = client_data.get("client_type", "chat")
-    if client_type == "quick":
+    client_type = client_data.get("client_type", "CHAT")
+    if client_type == "QUICK":
         logger.warning(f"QUICK client {client_data['id']} attempted WS connection")
-        await websocket.close(code=4003, reason="Client type 'quick' not allowed on WebSocket")
+        await websocket.close(code=4003, reason="Client type 'QUICK' not allowed on WebSocket")
         return
         
     client_id = client_data["id"]
@@ -71,7 +71,7 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
         model_id = websocket.query_params.get("model_id") or None
         if not conversation_id:
             conversation = await memory_manager.create_conversation(
-                user_id, client_id=client_id, model_id=model_id
+                client_id=client_id, model_id=model_id
             )
             conversation_id = conversation["id"]
             logger.info(

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -122,7 +122,7 @@ class MemoryManager:
             logger.error(f"Error validating client key: {e}")
             return False
 
-    async def create_conversation(self, user_id: str, client_id: int, model_id: Optional[str] = None) -> Dict[str, Any]:
+    async def create_conversation(self, client_id: Any, model_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Creates a new conversation in JotaDB.
         Optionally links it to a specific model via model_id.
@@ -135,7 +135,7 @@ class MemoryManager:
                 "X-Client-ID": str(client_id)
             }
 
-            payload: Dict[str, Any] = {"client_id": user_id, "status": "active"}
+            payload: Dict[str, Any] = {"client_id": client_id, "status": "active"}
             if model_id:
                 payload["model_id"] = model_id
 
@@ -148,7 +148,7 @@ class MemoryManager:
             return create_response.json()
 
         except Exception as e:
-            logger.error(f"Error managing conversation for user {user_id}: {e}")
+            logger.error(f"Error managing conversation for client {client_id}: {e}")
             raise e
 
     async def get_conversation(self, conversation_id: str, client_id: Any) -> Optional[Dict[str, Any]]:
@@ -279,7 +279,7 @@ class MemoryManager:
         try:
             payload: Dict[str, Any] = {"role": role, "content": content}
             if metadata:
-                payload["metadata"] = metadata
+                payload["extra_data"] = metadata
 
             service_headers = {
                 **self.base_headers,


### PR DESCRIPTION
## Summary

- **`create_conversation()`** — eliminado parámetro `user_id`, el payload ahora usa `client_id` (UUID real de jota-db). Antes se enviaba el string libre del path del gateway (e.g. `"esp32-kitchen"`), causando violaciones de FK en la DB.
- **`save_message()`** — renombrado `metadata` → `extra_data` en el payload JSON para coincidir con el schema actualizado de jota-db (PR #5 de jota-db).
- **`websocket.py`** — comparación de `client_type` contra `QUICK`/`CHAT` en mayúsculas, consistente con los valores que devuelve jota-db y con el fix ya mergeado en `quick.py`.

Cierra issue #9 de jota-orchestrator (Fase 0).

## Test plan
- [ ] 33/33 tests unitarios e integración pasan
- [ ] Verificar que POST `/chat/conversations` llega a jota-db con un UUID válido en `client_id`
- [ ] Verificar que POST `/chat/{id}/messages` con tool results no devuelve 422
- [ ] Verificar que cliente QUICK no puede conectar por WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)