### PR TITLE
refactor: eliminate user_id from routes and internal API

### DIFF
--- a/CLIENT_ENDPOINTS.md
+++ b/CLIENT_ENDPOINTS.md
@@ -9,13 +9,13 @@
    - `GET /health` — Health Check
 4. [Endpoints de Datos (`/api`)](#endpoints-de-datos-api)
    - `GET /api/models` — Listar modelos
-   - `GET /api/conversations/{user_id}` — Listar conversaciones
-   - `GET /api/conversations/{user_id}/{conversation_id}/messages` — Mensajes
+   - `GET /api/conversations` — Listar conversaciones
+   - `GET /api/conversations/{conversation_id}/messages` — Mensajes
    - `PATCH /api/conversations/{conversation_id}/model` — Cambiar modelo
 5. [Endpoint QUICK (`/api/quick`)](#endpoint-quick-apiquick)
    - `POST /api/quick` — Comando rápido con streaming NDJSON
 6. [Endpoint CHAT (`/api/chat`)](#endpoint-chat-apichat)
-   - `WebSocket /api/chat/ws/{user_id}` — Chat en tiempo real
+   - `WebSocket /api/chat/ws` — Chat en tiempo real
 7. [Códigos de Error](#códigos-de-error)
 
 ---
@@ -30,7 +30,7 @@ JotaOrchestrator distingue dos tipos de clientes. El tipo se configura en JotaDB
 
 | `client_type` | Endpoints permitidos | Caso de uso |
 |---------------|---------------------|-------------|
-| `chat` | `/api/chat/ws/...` + todos los de `/api/` | Aplicaciones de conversación, interfaces web |
+| `chat` | `/api/chat/ws` + todos los de `/api/` | Aplicaciones de conversación, interfaces web |
 | `quick` | `/api/quick` + todos los de `/api/` | Agentes de voz, domótica, comandos rápidos |
 
 ### Mecanismo de autenticación
@@ -38,7 +38,7 @@ JotaOrchestrator distingue dos tipos de clientes. El tipo se configura en JotaDB
 - **Header HTTP:** `x-client-key: <tu_clave_de_cliente>`
 - **Query param WebSocket:** `?x_client_key=<clave>` o `?client_key=<clave>` (para clientes que no soporten cabeceras personalizadas al abrir el WebSocket)
 - La clave se valida en JotaDB en cada petición. Si es inválida o falta → `401 Unauthorized`.
-- La validación devuelve internamente el `client_id` numérico, que aísla los datos de cada cliente (las conversaciones y mensajes pertenecen al `client_id`, no solo al `user_id`).
+- La validación devuelve internamente el `client_id` UUID, que aísla los datos de cada cliente.
 
 > ⚠️ Las credenciales `ORCHESTRATOR_API_KEY` y `JOTA_DB_SK` son internas del servidor. El cliente nunca debe conocerlas.
 
@@ -51,13 +51,13 @@ GET  /                                              — Liveness check (sin auth
 GET  /health                                        — Health check profundo (sin auth)
 
 GET  /api/models                                    — Lista modelos del Engine
-GET  /api/conversations/{user_id}                   — Lista conversaciones
-GET  /api/conversations/{user_id}/{conv_id}/messages — Historial de mensajes
+GET  /api/conversations                             — Lista conversaciones del cliente
+GET  /api/conversations/{conv_id}/messages          — Historial de mensajes
 PATCH /api/conversations/{conv_id}/model            — Cambia modelo de conversación
 
 POST /api/quick                                     — Comando rápido NDJSON (client_type: quick)
 
-WS   /api/chat/ws/{user_id}                         — Chat en tiempo real (client_type: chat)
+WS   /api/chat/ws                                   — Chat en tiempo real (client_type: chat)
 ```
 
 ---
@@ -147,14 +147,9 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
 
 ---
 
-### `GET /api/conversations/{user_id}`
+### `GET /api/conversations`
 
-**Descripción:** Lista las últimas N conversaciones filtradas por `client_id`. Un cliente no puede ver conversaciones de otro.
-
-**Parámetros de ruta:**
-| Parámetro | Tipo | Descripción |
-|-----------|------|-------------|
-| `user_id` | string | Identificador del usuario |
+**Descripción:** Lista las últimas N conversaciones del cliente autenticado. La identidad se resuelve desde la `x-client-key`.
 
 **Query params:**
 | Parámetro | Tipo | Default | Rango | Descripción |
@@ -173,7 +168,7 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
   "conversations": [
     {
       "id": "conv-uuid-1234",
-      "user_id": "usuario1",
+      "client_id": "client-uuid-5678",
       "model_id": "llama-3-8b-instruct",
       "created_at": "2026-03-03T17:00:00Z",
       "updated_at": "2026-03-03T17:45:00Z"
@@ -190,14 +185,13 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
 
 ---
 
-### `GET /api/conversations/{user_id}/{conversation_id}/messages`
+### `GET /api/conversations/{conversation_id}/messages`
 
 **Descripción:** Devuelve el historial de mensajes de una conversación ordenados cronológicamente. Filtrado por `client_id`.
 
 **Parámetros de ruta:**
 | Parámetro | Tipo | Descripción |
 |-----------|------|-------------|
-| `user_id` | string | Identificador del usuario |
 | `conversation_id` | string | UUID de la conversación |
 
 **Query params:**
@@ -221,7 +215,7 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
       "role": "user",
       "content": "Busca información sobre energía solar",
       "created_at": "2026-03-03T17:00:10Z",
-      "metadata": null
+      "extra_data": null
     },
     {
       "id": "msg-uuid-0002",
@@ -229,7 +223,7 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
       "role": "assistant",
       "content": "La energía solar es una fuente de energía renovable...",
       "created_at": "2026-03-03T17:00:18Z",
-      "metadata": {
+      "extra_data": {
         "model_id": "llama-3-8b-instruct"
       }
     },
@@ -239,7 +233,7 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
       "role": "tool",
       "content": "{\"results\": [{\"title\": \"Solar energy overview...\"}]}",
       "created_at": "2026-03-03T17:00:14Z",
-      "metadata": {
+      "extra_data": {
         "tool_name": "web_search",
         "execution_time": "1.45s"
       }
@@ -250,8 +244,8 @@ Disponibles para ambos tipos de cliente (`chat` y `quick`). Todos requieren `x-c
 
 **Roles de mensaje:**
 - `user` — Mensaje del usuario.
-- `assistant` — Respuesta del modelo. `metadata.model_id` indica qué modelo la generó.
-- `tool` — Resultado de una herramienta ejecutada. `metadata.tool_name` y `metadata.execution_time` proporcionan trazabilidad.
+- `assistant` — Respuesta del modelo. `extra_data.model_id` indica qué modelo la generó.
+- `tool` — Resultado de una herramienta ejecutada. `extra_data.tool_name` y `extra_data.execution_time` proporcionan trazabilidad.
 - `system` — Mensajes de sistema internos.
 
 **Errores:**
@@ -329,7 +323,6 @@ Soporta ejecución de herramientas (p. ej. `web_search`): en ese caso se emiten 
 ```json
 {
   "text": "¿Qué tiempo hace en Madrid?",
-  "user_id": "voice_user",
   "model_id": "llama-3-8b-instruct"
 }
 ```
@@ -337,7 +330,6 @@ Soporta ejecución de herramientas (p. ej. `web_search`): en ese caso se emiten 
 | Campo | Tipo | Requerido | Default | Descripción |
 |-------|------|-----------|---------|-------------|
 | `text` | string | ✅ | — | Comando o pregunta del usuario |
-| `user_id` | string | ❌ | `"quick_user"` | Identificador del usuario (solo para logs) |
 | `model_id` | string | ❌ | `null` | Modelo a usar. Si `null`, usa el cargado actualmente en el Engine. |
 
 **Respuesta: stream NDJSON**
@@ -380,7 +372,7 @@ const response = await fetch("http://localhost:8000/api/quick", {
     "Content-Type": "application/json",
     "x-client-key": "mi_clave_quick"
   },
-  body: JSON.stringify({ text: "Pon un timer de 5 minutos", user_id: "voice" })
+  body: JSON.stringify({ text: "Pon un timer de 5 minutos" })
 });
 
 const reader = response.body.getReader();
@@ -413,22 +405,17 @@ speakTTS(buffer); // Reproducir respuesta acumulada
 
 Para clientes de tipo `chat`. Conversación persistente multi-turno con streaming de tokens en tiempo real.
 
-### `WebSocket /api/chat/ws/{user_id}`
+### `WebSocket /api/chat/ws`
 
-**Descripción:** Conexión WebSocket persistente para chat en tiempo real. Soporta conversaciones multi-turno, cambio de modelo mid-session y ejecución de herramientas.
+**Descripción:** Conexión WebSocket persistente para chat en tiempo real. Soporta conversaciones multi-turno, cambio de modelo mid-session y ejecución de herramientas. La identidad del cliente se resuelve desde la `x-client-key`.
 
 **URL de conexión:**
 ```
-ws://host:port/api/chat/ws/{user_id}
+ws://host:port/api/chat/ws
   ?conversation_id=conv-uuid-1234    (opcional — retoma conversación existente)
   ?model_id=llama-3-8b-instruct      (opcional — modelo a usar)
   &x_client_key=<tu_clave>           (o via header x-client-key)
 ```
-
-**Parámetros de ruta:**
-| Parámetro | Tipo | Descripción |
-|-----------|------|-------------|
-| `user_id` | string | Identificador del usuario |
 
 **Query params:**
 | Parámetro | Tipo | Requerido | Descripción |
@@ -451,7 +438,7 @@ APERTURA
   ├─ Validación client_type != "quick"       → close(4003) si es quick
   ├─ Verificación Engine disponible          → close(1011) si no disponible
   ├─ Gestión de conversación                 → create_conversation() si no hay conversation_id
-  ├─ ensure_session()                        → cierra sesión previa del user_id si existía
+  ├─ ensure_session(client_id)              → cierra sesión previa del cliente si existía
   ├─ get_conversation_messages() + set_context() → inyecta historial en el Engine
   └─ websocket.accept()                      → conexión lista
 
@@ -460,7 +447,7 @@ BUCLE DE MENSAJES
   └─ Recibir JSON con "type" → mensaje de control (ver abajo)
 
 CIERRE
-  └─ release_session(user_id)
+  └─ release_session(client_id)
 ```
 
 #### Protocolo de mensajes
@@ -503,7 +490,7 @@ CIERRE
 
 ```javascript
 const ws = new WebSocket(
-  `ws://localhost:8000/api/chat/ws/usuario1` +
+  `ws://localhost:8000/api/chat/ws` +
   `?conversation_id=conv-uuid-1234` +
   `&x_client_key=mi_clave_chat`
 );
@@ -544,7 +531,7 @@ ws.onclose = (e) => console.log(`Cerrado: código ${e.code}`);
 - Al abrirse la conexión, el Orchestrator **recupera automáticamente** el historial de la `conversation_id` desde JotaDB e inyecta los mensajes como contexto en el InferenceEngine.
 - Cada mensaje de usuario y cada respuesta del asistente se **persisten automáticamente** en JotaDB.
 - Si la inferencia se interrumpe por desconexión abrupta, la respuesta parcial se guarda con el sufijo `[INTERRUPTED]`.
-- El InferenceEngine mantiene **una sesión activa por `user_id`** a la vez. Abrir una nueva conexión para el mismo `user_id` cierra la sesión anterior.
+- El InferenceEngine mantiene **una sesión activa por `client_id`** a la vez. Abrir una nueva conexión con el mismo cliente cierra la sesión anterior.
 
 ---
 

--- a/src/api/chat/websocket.py
+++ b/src/api/chat/websocket.py
@@ -13,8 +13,8 @@ import logging
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-@router.websocket("/chat/ws/{user_id}")
-async def websocket_endpoint(websocket: WebSocket, user_id: str):
+@router.websocket("/chat/ws")
+async def websocket_endpoint(websocket: WebSocket):
     """
     Handles a full WebSocket chat session.
 
@@ -24,40 +24,36 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
     3. Ensure an Ephemeral Session on the Inference Center.
     4. Recover database context and inject it.
     5. Listen to text inputs and control streams via JSON envelopes.
-
-    Args:
-        websocket: The active WebSocket connection.
-        user_id: The ID of the connecting user.
     """
     # 1. Authentication
     # Allow passing auth token via query params for simpler WebSocket clients
     client_key = websocket.headers.get("x-client-key") or websocket.query_params.get("x_client_key") or websocket.query_params.get("client_key")
     if not client_key:
-        logger.warning(f"Missing Client Key header or query param for user {user_id}")
+        logger.warning("Missing Client Key header or query param")
         await websocket.close(code=4001, reason="Unauthorized")
         return
-        
+
     client_data = await memory_manager.validate_client_key(client_key)
     if not client_data:
-        logger.warning(f"Unauthorized access attempt for user {user_id}")
+        logger.warning("Unauthorized access attempt")
         await websocket.close(code=4001, reason="Unauthorized")
         return
-        
+
     # 2. Validar tipo de cliente
     client_type = client_data.get("client_type", "CHAT")
     if client_type == "QUICK":
         logger.warning(f"QUICK client {client_data['id']} attempted WS connection")
         await websocket.close(code=4003, reason="Client type 'QUICK' not allowed on WebSocket")
         return
-        
+
     client_id = client_data["id"]
 
     await websocket.accept()
-    logger.info(f"WebSocket connected for user {user_id}")
+    logger.info(f"WebSocket connected for client {client_id}")
 
     # Fail fast if Engine is not connected
     if not inference_client.is_connected:
-        logger.error(f"Inference Engine not connected — closing WS for {user_id}")
+        logger.error(f"Inference Engine not connected — closing WS for client {client_id}")
         await websocket.send_text(_json.dumps({
             "type": "error",
             "message": "Inference Engine no disponible. Intenta de nuevo en unos segundos."
@@ -76,7 +72,7 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
             conversation_id = conversation["id"]
             logger.info(
                 f"[TRACE][Conv: {conversation_id}] New conversation created "
-                f"for user={user_id} model_id={model_id!r}"
+                f"for client={client_id} model_id={model_id!r}"
             )
         elif model_id:
             # Client reconnected with an existing conversation and a new model_id.
@@ -94,7 +90,7 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
             )
 
         # 3. Ephemeral Session (aborts previous if exists)
-        session_id = await inference_client.ensure_session(user_id)
+        session_id = await inference_client.ensure_session(client_id)
 
         # 4. Recover context from DB and inject into session
         context = await memory_manager.get_conversation_messages(conversation_id, client_id)
@@ -158,7 +154,6 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
             # 5. Save User Message (text prompt)
             await memory_manager.save_message(
                 conversation_id=conversation_id,
-                user_id=user_id,
                 role="user",
                 content=data,
                 client_id=client_id
@@ -168,7 +163,6 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
                 "content": data,
                 "session_id": session_id,
                 "conversation_id": conversation_id,
-                "user_id": user_id,
                 "client_id": client_id,
                 "model_id": model_id,
                 "source": "websocket"
@@ -189,12 +183,12 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
                     await websocket.send_text(_json.dumps({"type": "token", "content": token}))
             
     except WebSocketDisconnect:
-        logger.info(f"WebSocket disconnected for user {user_id}")
+        logger.info(f"WebSocket disconnected for client {client_id}")
 
     except Exception as e:
-        logger.error(f"WebSocket error for user {user_id}: {e}")
+        logger.error(f"WebSocket error for client {client_id}: {e}")
         await websocket.close(code=1011)
 
     finally:
         # Always release session on any exit path
-        await inference_client.release_session(user_id)
+        await inference_client.release_session(client_id)

--- a/src/api/quick.py
+++ b/src/api/quick.py
@@ -43,27 +43,25 @@ Ejemplos de respuesta correcta:
 class QuickRequest(BaseModel):
     """Petición para el endpoint QUICK."""
     text: str
-    user_id: str = "quick_user"
     model_id: Optional[str] = None
 
 
 async def _quick_stream_generator(
-    client_id: int, 
-    user_id: str, 
-    session_id: str, 
-    text: str, 
+    client_id: str,
+    session_id: str,
+    text: str,
     model_id: Optional[str]
 ) -> AsyncGenerator[str, None]:
     """Generador que emite líneas JSON (NDJSON) con tokens de texto y metadatos."""
     
     log_prefix = f"[QUICK][Sess: {session_id}]"
-    
+
     # Preparamos el system prompt incluyendo instrucciones de tools si aplica
     tool_instructions = tool_manager.get_system_prompt_addition(client_id=client_id)
     full_prompt = f"{QUICK_SYSTEM_PROMPT}\n"
     if tool_instructions:
         full_prompt += f"\n{tool_instructions}\n"
-    
+
     # Parámetros optimizados para respuestas cortas (primera pasada)
     quick_params = {
         "temp": 0.3,
@@ -76,20 +74,19 @@ async def _quick_stream_generator(
         "max_tokens": 100,
         "system_prompt": full_prompt
     }
-    
+
     tool_executed = False
-    
+
     try:
         # 1. Primera pasada de inferencia
         async for token in inference_client.infer(
             session_id=session_id,
             prompt=text,
             conversation_id=f"quick_{session_id}",
-            user_id=user_id,
             params=quick_params,
             client_id=client_id,
             model_id=model_id,
-            persist_messages=False, # Stateless HTTP run
+            persist_messages=False,  # Stateless HTTP run
         ):
             if isinstance(token, dict) and token.get("type") == "tool_call":
                 tc_payload = token.get("payload", {})
@@ -135,7 +132,6 @@ async def _quick_stream_generator(
                 session_id=session_id,
                 prompt=settings.TOOL_FOLLOWUP_PROMPT,
                 conversation_id=f"quick_{session_id}",
-                user_id=user_id,
                 params=quick_final_params,
                 client_id=client_id,
                 model_id=model_id,
@@ -203,10 +199,9 @@ async def quick_endpoint(
     return StreamingResponse(
         _quick_stream_generator(
             client_id=client_id,
-            user_id=request.user_id,
             session_id=session_id,
             text=request.text,
-            model_id=request.model_id
+            model_id=request.model_id,
         ),
         media_type="application/x-ndjson"
     )

--- a/src/api/rest.py
+++ b/src/api/rest.py
@@ -10,8 +10,8 @@ incluídos aquí.
 
 Rutas base (todas bajo el prefijo /api definido en main.py):
   GET    /api/models
-  GET    /api/conversations/{user_id}
-  GET    /api/conversations/{user_id}/{conversation_id}/messages
+  GET    /api/conversations
+  GET    /api/conversations/{conversation_id}/messages
   PATCH  /api/conversations/{conversation_id}/model
 """
 from fastapi import APIRouter, Query, Header, HTTPException
@@ -63,11 +63,10 @@ async def get_models(
 # ===========================================================================
 
 @router.get(
-    "/conversations/{user_id}",
-    summary="Lista las últimas N conversaciones de un usuario",
+    "/conversations",
+    summary="Lista las últimas N conversaciones del cliente autenticado",
 )
 async def get_conversations(
-    user_id: str,
     x_client_key: str = Header(..., description="Client authentication key"),
     limit: int = Query(10, ge=1, le=100, description="Número de conversaciones a devolver"),
 ):
@@ -78,16 +77,15 @@ async def get_conversations(
         conversations = await memory_manager.get_user_conversations(client_id, limit=limit)
         return {"status": "success", "conversations": conversations}
     except Exception as e:
-        logger.error(f"Error listing conversations for {user_id}: {e}")
+        logger.error(f"Error listing conversations for client {client_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get(
-    "/conversations/{user_id}/{conversation_id}/messages",
+    "/conversations/{conversation_id}/messages",
     summary="Devuelve los mensajes de una conversación",
 )
 async def get_conversation_messages(
-    user_id: str,
     conversation_id: str,
     x_client_key: str = Header(..., description="Client authentication key"),
     limit: int = Query(50, ge=1, le=1000, description="Número de mensajes a devolver"),

--- a/src/core/controller/input.py
+++ b/src/core/controller/input.py
@@ -33,14 +33,13 @@ class JotaInputMixin:
         content = payload.get("content")
         session_id = payload.get("session_id")
         conversation_id = payload.get("conversation_id")
-        user_id = payload.get("user_id")
         client_id = payload.get("client_id")
         model_id = payload.get("model_id")
         stateless = payload.get("stateless", False)
         system_prompt_override = payload.get("system_prompt_override")
 
-        if not session_id or not conversation_id or not user_id:
-            logger.error("Missing session_id, conversation_id, or user_id in payload")
+        if not session_id or not conversation_id or not client_id:
+            logger.error("Missing session_id, conversation_id, or client_id in payload")
             yield " [Error: Internal Context Missing]"
             return
 
@@ -88,7 +87,6 @@ class JotaInputMixin:
                 session_id=session_id,
                 prompt=content,
                 conversation_id=conversation_id,
-                user_id=user_id,
                 params=infer_params,
                 client_id=client_id,
                 model_id=effective_model,
@@ -105,7 +103,6 @@ class JotaInputMixin:
                         if not stateless:
                             await self.memory_manager.save_message(
                                 conversation_id=conversation_id,
-                                user_id=user_id,
                                 role="assistant",
                                 content=thinking_text,
                                 client_id=client_id,
@@ -126,7 +123,6 @@ class JotaInputMixin:
                         if not stateless:
                             await self.memory_manager.save_message(
                                 conversation_id=conversation_id,
-                                user_id=user_id,
                                 role="tool",
                                 content=result_str,
                                 client_id=client_id,
@@ -139,7 +135,6 @@ class JotaInputMixin:
                         if not stateless:
                             await self.memory_manager.save_message(
                                 conversation_id=conversation_id,
-                                user_id=user_id,
                                 role="tool",
                                 content=f"Error executing tool {tool_name}: {e}",
                                 client_id=client_id,
@@ -165,7 +160,6 @@ class JotaInputMixin:
                             if clean_thinking.strip() and not stateless:
                                 await self.memory_manager.save_message(
                                     conversation_id=conversation_id,
-                                    user_id=user_id,
                                     role="assistant",
                                     content=clean_thinking,
                                     client_id=client_id,
@@ -184,7 +178,6 @@ class JotaInputMixin:
                                 if not stateless:
                                     await self.memory_manager.save_message(
                                         conversation_id=conversation_id,
-                                        user_id=user_id,
                                         role="tool",
                                         content=result_str,
                                         client_id=client_id,
@@ -197,7 +190,6 @@ class JotaInputMixin:
                                 if not stateless:
                                     await self.memory_manager.save_message(
                                         conversation_id=conversation_id,
-                                        user_id=user_id,
                                         role="tool",
                                         content=f"Error executing tool {tool_name}: {e}",
                                         client_id=client_id,
@@ -228,7 +220,6 @@ class JotaInputMixin:
                     session_id=session_id,
                     prompt=followup_prompt,
                     conversation_id=conversation_id,
-                    user_id=user_id,
                     params=infer_params,
                     client_id=client_id,
                     model_id=effective_model,

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -258,7 +258,6 @@ class MemoryManager:
     async def save_message(
         self,
         conversation_id: str,
-        user_id: str,
         role: Literal["user", "assistant", "system", "tool"],
         content: str,
         client_id: Any,

--- a/src/main.py
+++ b/src/main.py
@@ -91,7 +91,7 @@ app.add_middleware(
 )
 
 # Route layout:
-#   /api/chat  → WebSocket only  (ws://host/api/chat/ws/{user_id})
+#   /api/chat  → WebSocket only  (ws://host/api/chat/ws)
 #   /api/quick → HTTP NDJSON     (POST http://host/api/quick)
 #   /api/*     → REST data & config (models, conversations, settings…)
 app.include_router(chat_router, prefix="/api")

--- a/src/services/inference/client.py
+++ b/src/services/inference/client.py
@@ -43,7 +43,7 @@ class InferenceClient(InferenceConnectionMixin, InferenceSessionMixin):
         self.lock = asyncio.Lock()
         
         self.active_sessions: Dict[str, str] = {}
-        self._user_sessions: Dict[str, str] = {}  # user_id -> session_id tracking
+        self._user_sessions: Dict[str, str] = {}  # client_id -> session_id tracking
         self._response_queues: Dict[str, asyncio.Queue] = {}
         self._pending_sessions: Dict[str, asyncio.Future] = {}
         self._pending_commands: Dict[str, asyncio.Future] = {}
@@ -135,9 +135,8 @@ class InferenceClient(InferenceConnectionMixin, InferenceSessionMixin):
         session_id: str,
         prompt: str,
         conversation_id: str,
-        user_id: str,
         params: Optional[Dict[str, Any]] = None,
-        client_id: int = None,
+        client_id: Any = None,
         model_id: Optional[str] = None,
         persist_messages: bool = True,
     ) -> AsyncGenerator[Any, None]:
@@ -252,7 +251,6 @@ class InferenceClient(InferenceConnectionMixin, InferenceSessionMixin):
                     if persist_messages:
                         await self.memory_manager.save_message(
                             conversation_id=conversation_id,
-                            user_id=user_id,
                             role="assistant",
                             content=full_text,
                             client_id=client_id,
@@ -273,14 +271,13 @@ class InferenceClient(InferenceConnectionMixin, InferenceSessionMixin):
                 if persist_messages:
                     await self.memory_manager.save_message(
                         conversation_id=conversation_id,
-                        user_id=user_id,
                         role="assistant",
                         content=partial_response,
                         client_id=client_id,
                         metadata={"model_id": model_id, "interrupted": True} if model_id else {"interrupted": True},
                     )
-            
-            await self.memory_manager.mark_conversation_error(conversation_id, user_id)
+
+            await self.memory_manager.mark_conversation_error(conversation_id, client_id)
             raise e
         finally:
              if session_id in self._response_queues:

--- a/src/services/inference/session_manager.py
+++ b/src/services/inference/session_manager.py
@@ -61,19 +61,19 @@ class InferenceSessionMixin:
              except Exception as e:
                  logger.error(f"Failed to close session {session_id}: {e}")
 
-    async def ensure_session(self, user_id: str) -> str:
+    async def ensure_session(self, client_id: str) -> str:
         """
-        Creates a fresh session for a user, closing any existing one first.
+        Creates a fresh session for a client, closing any existing one first.
         Tracks active sessions to avoid leaving dangling resources.
         """
-        old_session = self._user_sessions.get(user_id)
+        old_session = self._user_sessions.get(client_id)
         if old_session:
-            logger.info(f"Closing previous session {old_session} for user {user_id}")
+            logger.info(f"Closing previous session {old_session} for client {client_id}")
             await self.close_session(old_session)
-        
+
         session_id = await self.create_session()
-        self._user_sessions[user_id] = session_id
-        logger.info(f"New session {session_id} assigned to user {user_id}")
+        self._user_sessions[client_id] = session_id
+        logger.info(f"New session {session_id} assigned to client {client_id}")
         return session_id
 
     async def set_context(self, session_id: str, messages: list):
@@ -94,12 +94,12 @@ class InferenceSessionMixin:
         await self.websocket.send(json.dumps(payload))
         logger.info(f"Context set for session {session_id} ({len(messages)} messages)")
 
-    async def release_session(self, user_id: str):
+    async def release_session(self, client_id: str):
         """
-        Closes and unregisters a user's active session.
+        Closes and unregisters a client's active session.
         Called on client disconnect to free InferenceCenter resources.
         """
-        session_id = self._user_sessions.pop(user_id, None)
+        session_id = self._user_sessions.pop(client_id, None)
         if session_id:
-            logger.info(f"Releasing session {session_id} for user {user_id}")
+            logger.info(f"Releasing session {session_id} for client {client_id}")
             await self.close_session(session_id)

--- a/tests/integration/test_inference_flow.py
+++ b/tests/integration/test_inference_flow.py
@@ -36,7 +36,6 @@ async def test_full_inference_flow(mock_server, mock_memory_manager):
         async for token in client.infer(
             session_id, prompt,
             conversation_id="conv_test_1",
-            user_id="user_test_1"
         ):
             received_tokens.append(token)
 
@@ -60,21 +59,20 @@ async def test_concurrent_sessions(mock_server, mock_memory_manager):
     connected = await client.verify_connection(timeout=5.0)
     assert connected
 
-    async def run_session(user_id):
+    async def run_session(client_id):
         session_id = await client.create_session()
         tokens = []
         async for token in client.infer(
             session_id, "prompt",
-            conversation_id=f"conv_{user_id}",
-            user_id=user_id
+            conversation_id=f"conv_{client_id}",
         ):
             tokens.append(token)
         return "".join(tokens)
 
     results = await asyncio.gather(
-        run_session("user_1"),
-        run_session("user_2"),
-        run_session("user_3")
+        run_session("client_1"),
+        run_session("client_2"),
+        run_session("client_3")
     )
 
     for res in results:


### PR DESCRIPTION
Closes #13

## Resumen

Elimina el concepto residual de `user_id` de todas las rutas, firmas de métodos y payloads internos del orchestrator. La identidad del cliente se resuelve siempre desde `x-client-key` → UUID real de jota-db (`client_id`).

## Cambios

### Rutas
- `WS /api/chat/ws/{user_id}` → `/api/chat/ws`
- `GET /api/conversations/{user_id}` → `/api/conversations`
- `GET /api/conversations/{user_id}/{conv_id}/messages` → `/api/conversations/{conv_id}/messages`

### Firmas
- `save_message(user_id, ...)` → parámetro eliminado (no se usaba en el payload)
- `infer(user_id, ...)` → parámetro eliminado
- `ensure_session(user_id)` / `release_session(user_id)` → renombrados a `client_id`
- `QuickRequest.user_id` → eliminado del body

### Bug fix
- `client.py`: `mark_conversation_error(conversation_id, user_id)` → `mark_conversation_error(conversation_id, client_id)`. El bug enviaba `X-Client-ID` incorrecto a jota-db en caso de error de inferencia.

### Docs
- `CLIENT_ENDPOINTS.md`: rutas actualizadas, `metadata` → `extra_data` en ejemplos de mensajes

## Test plan

- [x] 33/33 tests pasan (`pytest tests/unit/ tests/integration/`)
- [x] Tests de integración actualizados para la nueva firma de `infer()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)