### PR TITLE
feat: QuickRequest acepta system_prompt_extra

### DIFF
--- a/src/api/quick.py
+++ b/src/api/quick.py
@@ -44,13 +44,15 @@ class QuickRequest(BaseModel):
     """Petición para el endpoint QUICK."""
     text: str
     model_id: Optional[str] = None
+    system_prompt_extra: Optional[str] = None
 
 
 async def _quick_stream_generator(
     client_id: str,
     session_id: str,
     text: str,
-    model_id: Optional[str]
+    model_id: Optional[str],
+    system_prompt_extra: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """Generador que emite líneas JSON (NDJSON) con tokens de texto y metadatos."""
     
@@ -61,6 +63,8 @@ async def _quick_stream_generator(
     full_prompt = f"{QUICK_SYSTEM_PROMPT}\n"
     if tool_instructions:
         full_prompt += f"\n{tool_instructions}\n"
+    if system_prompt_extra:
+        full_prompt += f"\n{system_prompt_extra}\n"
 
     # Parámetros optimizados para respuestas cortas (primera pasada)
     quick_params = {
@@ -202,6 +206,7 @@ async def quick_endpoint(
             session_id=session_id,
             text=request.text,
             model_id=request.model_id,
+            system_prompt_extra=request.system_prompt_extra,
         ),
         media_type="application/x-ndjson"
     )

--- a/tests/unit/test_quick_system_prompt.py
+++ b/tests/unit/test_quick_system_prompt.py
@@ -34,6 +34,7 @@ def mock_tools():
         yield mock
 
 
+@pytest.mark.asyncio
 async def test_system_prompt_extra_appended_when_provided(mock_inference, mock_tools):
     from src.api.quick import _quick_stream_generator
 
@@ -51,6 +52,7 @@ async def test_system_prompt_extra_appended_when_provided(mock_inference, mock_t
     assert "responde siempre en inglés" in call_kwargs["params"]["system_prompt"]
 
 
+@pytest.mark.asyncio
 async def test_system_prompt_extra_not_present_when_none(mock_inference, mock_tools):
     from src.api.quick import _quick_stream_generator, QUICK_SYSTEM_PROMPT
 
@@ -69,6 +71,7 @@ async def test_system_prompt_extra_not_present_when_none(mock_inference, mock_to
     assert system_prompt.strip().startswith(QUICK_SYSTEM_PROMPT.strip())
 
 
+@pytest.mark.asyncio
 async def test_system_prompt_extra_empty_string_ignored(mock_inference, mock_tools):
     from src.api.quick import _quick_stream_generator, QUICK_SYSTEM_PROMPT
 

--- a/tests/unit/test_quick_system_prompt.py
+++ b/tests/unit/test_quick_system_prompt.py
@@ -1,0 +1,87 @@
+"""Tests: _quick_stream_generator appends system_prompt_extra to full_prompt."""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+async def _collect(gen) -> list[dict]:
+    results = []
+    async for line in gen:
+        line = line.strip()
+        if line:
+            results.append(json.loads(line))
+    return results
+
+
+@pytest.fixture
+def mock_inference():
+    with patch("src.api.quick.inference_client") as mock:
+        mock.create_session = AsyncMock(return_value="sess-1")
+        mock.close_session = AsyncMock()
+        mock.set_context = AsyncMock()
+
+        async def fake_infer(*args, **kwargs):
+            yield "hola"
+
+        mock.infer = MagicMock(side_effect=fake_infer)
+        yield mock
+
+
+@pytest.fixture
+def mock_tools():
+    with patch("src.api.quick.tool_manager") as mock:
+        mock.get_system_prompt_addition = MagicMock(return_value=None)
+        yield mock
+
+
+async def test_system_prompt_extra_appended_when_provided(mock_inference, mock_tools):
+    from src.api.quick import _quick_stream_generator
+
+    await _collect(
+        _quick_stream_generator(
+            client_id="cid",
+            session_id="sess-1",
+            text="hola",
+            model_id=None,
+            system_prompt_extra="responde siempre en inglés",
+        )
+    )
+
+    call_kwargs = mock_inference.infer.call_args.kwargs
+    assert "responde siempre en inglés" in call_kwargs["params"]["system_prompt"]
+
+
+async def test_system_prompt_extra_not_present_when_none(mock_inference, mock_tools):
+    from src.api.quick import _quick_stream_generator, QUICK_SYSTEM_PROMPT
+
+    await _collect(
+        _quick_stream_generator(
+            client_id="cid",
+            session_id="sess-1",
+            text="hola",
+            model_id=None,
+            system_prompt_extra=None,
+        )
+    )
+
+    call_kwargs = mock_inference.infer.call_args.kwargs
+    system_prompt = call_kwargs["params"]["system_prompt"]
+    assert system_prompt.strip().startswith(QUICK_SYSTEM_PROMPT.strip())
+
+
+async def test_system_prompt_extra_empty_string_ignored(mock_inference, mock_tools):
+    from src.api.quick import _quick_stream_generator, QUICK_SYSTEM_PROMPT
+
+    await _collect(
+        _quick_stream_generator(
+            client_id="cid",
+            session_id="sess-1",
+            text="hola",
+            model_id=None,
+            system_prompt_extra="",
+        )
+    )
+
+    call_kwargs = mock_inference.infer.call_args.kwargs
+    system_prompt = call_kwargs["params"]["system_prompt"]
+    assert system_prompt.strip().startswith(QUICK_SYSTEM_PROMPT.strip())


### PR DESCRIPTION
Contiene:
- `refactor: eliminate user_id from routes and internal API`
- `feat: QuickRequest accepts system_prompt_extra — appended to system prompt`
- `test: add @pytest.mark.asyncio decorators for consistency`

> ⚠️ PR #16 se mergeó accidentalmente en `refactor/remove-user-id` en vez de `main`. Este PR lleva ambas features a main.